### PR TITLE
remove rigidbody dep from odometry.

### DIFF
--- a/Runtime/Tx/Msgs/Nav/OdometryTx.cs
+++ b/Runtime/Tx/Msgs/Nav/OdometryTx.cs
@@ -6,21 +6,26 @@ using ProBridge.Utils;
 namespace ProBridge.Tx.Nav
 {
     [AddComponentMenu("ProBridge/Tx/nav_msgs/Odometry")]
-    [RequireComponent(typeof(Rigidbody))]
     public class OdometryTx : ProBridgeTxStamped<Odometry>
     {
         public string childFrameId;
-        public bool localOrigin = false;
-        public Transform startPose;
+        public bool localOrigin= false;
+        public Transform startPos;
         public float[] covariancePose = new float[6] { 0.001f, 0.001f, 0.001f, 0.001f, 0.001f, 0.001f };
         public float[] covarianceTwist = new float[6] { 0.001f, 0.001f, 0.001f, 0.001f, 0.001f, 0.001f };
-        public Rigidbody Body { get; private set; }
         private Vector3 _startPose;
         private Quaternion _startRotation;
+
+        private Vector3 _previousPosition;
+        private Quaternion _previousRotation;
+
+        public Vector3 Velocity = new Vector3(0,0,0);
+        public Vector3 AngularVelocity = new Vector3(0,0,0);
+
         protected override void OnStart()
         {
-            Body = GetComponent<Rigidbody>();
-
+            _previousRotation = transform.rotation;
+            _previousPosition = transform.position;
             if (localOrigin)
             {
                 _startPose = transform.position;
@@ -28,28 +33,44 @@ namespace ProBridge.Tx.Nav
             }
         }
 
+        public void FixedUpdate()
+        {
+            Velocity = (transform.position - _previousPosition) / Time.fixedDeltaTime;
+            _previousPosition = transform.position;
+
+            Quaternion deltaRotation = transform.rotation * Quaternion.Inverse(_previousRotation);
+            float angle;
+            Vector3 axis;
+            deltaRotation.ToAngleAxis(out angle, out axis);
+
+            AngularVelocity = angle * axis.normalized / Time.fixedDeltaTime;
+            _previousRotation = transform.rotation;
+        }
+
         protected override ProBridge.Msg GetMsg(TimeSpan ts)
         {
-            data.child_frame_id = childFrameId;
             if (localOrigin)
             {
-                data.pose.pose.position = (Quaternion.Inverse(_startRotation) * (Body.position - _startPose)).ToRos();
-                data.pose.pose.orientation = (Quaternion.Inverse(_startRotation) * Body.rotation).ToRos();
+                data.pose.pose.position = (Quaternion.Inverse(_startRotation) * (transform.position - _startPose)).ToRos();
+                data.pose.pose.orientation = (Quaternion.Inverse(_startRotation) * transform.rotation).ToRos();
             }
             else
             {
-                data.pose.pose.position = startPose.InverseTransformPoint(Body.position).ToRos();
-                data.pose.pose.orientation = (Quaternion.Inverse(startPose.rotation) * Body.rotation).ToRos();
+                data.pose.pose.position = startPos.InverseTransformPoint(transform.position).ToRos();
+                data.pose.pose.orientation = (Quaternion.Inverse(startPos.rotation) * transform.rotation).ToRos();
             }
 
+
+            data.twist.twist.linear = (Quaternion.Inverse(transform.rotation) * Velocity).ToRos();
+            data.twist.twist.angular = (Quaternion.Inverse(transform.rotation) * AngularVelocity).ToRosAngular();
+
+            data.child_frame_id = childFrameId;
             data.pose.covariance[0] = covariancePose[0];
             data.pose.covariance[7] = covariancePose[1];
             data.pose.covariance[14] = covariancePose[2];
             data.pose.covariance[21] = covariancePose[3];
             data.pose.covariance[28] = covariancePose[4];
             data.pose.covariance[35] = covariancePose[5];
-            data.twist.twist.linear = (Quaternion.Inverse(Body.rotation) * Body.velocity).ToRos();
-            data.twist.twist.angular = (Quaternion.Inverse(Body.rotation) * Body.angularVelocity).ToRosAngular();
             data.twist.covariance[0] = covarianceTwist[0];
             data.twist.covariance[7] = covarianceTwist[1];
             data.twist.covariance[14] = covarianceTwist[2];


### PR DESCRIPTION
It also allows to specify the odometry start position.
![image](https://github.com/user-attachments/assets/30966709-02d7-4e15-8fbf-343775fa9fa6)

or leave the starting position at the initialization point, as it was before. It is enough to set True opposite LocalOrigin